### PR TITLE
Exclude city entries for Республика Беларусь

### DIFF
--- a/src/parsers/tatneft_parser.py
+++ b/src/parsers/tatneft_parser.py
@@ -113,6 +113,11 @@ class TatneftParser(BaseParser):
         longitude = station.get("lon") or station.get("longitude")
         number = station.get("number")
 
+        # Фильтруем станции из Беларуси
+        if region == "Республика Беларусь":
+            logger.debug(f"Пропускаем станцию {station_id} из Беларуси")
+            return []
+
         # Формируем адрес если он пустой
         if not address and region:
             address = region


### PR DESCRIPTION
Filter Tatneft stations from 'Республика Беларусь' to exclude them from the dataset.